### PR TITLE
Do not try to decode percent sign followed by invalid hex digits.

### DIFF
--- a/src/ring/util/codec.clj
+++ b/src/ring/util/codec.clj
@@ -47,7 +47,7 @@
   specified encoding, or UTF-8 by default."
   [^String encoded & [^String encoding]]
   (str/replace encoded
-               #"(?:%..)+"
+               #"(?:%[a-fA-F0-9]{2})+"
                (fn [chars]
                  (-> ^bytes (parse-bytes chars)
                      (String. (or encoding "UTF-8"))

--- a/test/ring/util/test/codec.clj
+++ b/test/ring/util/test/codec.clj
@@ -12,7 +12,8 @@
   (is (= (percent-decode "%20") " "))
   (is (= (percent-decode "foo%20bar") "foo bar"))
   (is (= (percent-decode "foo%FE%FF%00%2Fbar" "UTF-16") "foo/bar"))
-  (is (= (percent-decode "%24") "$")))
+  (is (= (percent-decode "%24") "$"))
+  (is (= (percent-decode "%zz") "%zz")))
 
 (deftest test-url-encode
   (is (= (url-encode "foo/bar") "foo%2Fbar"))


### PR DESCRIPTION
I think that when validating external input it is more important to get at least some result rather than non-informative NumberFormatException.
