### PR TITLE
Bumping commons-codec and codox plugin dependency versions, updating 1.5...

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,10 +4,10 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [commons-codec "1.6"]]
-  :plugins [[codox "0.6.4"]]
+                 [commons-codec "1.9"]]
+  :plugins [[codox "0.6.7"]]
   :codox {:src-dir-uri "http://github.com/ring-clojure/ring-codec/blob/1.0.0"
           :src-linenum-anchor-prefix "L"}
   :profiles
   {:1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
-   :1.5 {:dependencies [[org.clojure/clojure "1.5.0-RC1"]]}})
+   :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}})


### PR DESCRIPTION
... profile to use clojure 1.5.1

Signed-off-by: Thomas Steffes tsteffes@roomkey.com
