### PR TITLE
Only decode valid percent codes

### DIFF
--- a/src/ring/util/codec.clj
+++ b/src/ring/util/codec.clj
@@ -37,7 +37,7 @@
        (str/join)))
 
 (defn- parse-bytes [encoded-bytes]
-  (->> (re-seq #"%.." encoded-bytes)
+  (->> (re-seq #"%[A-Za-z0-9]{2}" encoded-bytes)
        (map #(subs % 1))
        (map #(.byteValue (Integer/valueOf % 16)))
        (byte-array)))
@@ -47,7 +47,7 @@
   specified encoding, or UTF-8 by default."
   [^String encoded & [^String encoding]]
   (str/replace encoded
-               #"(?:%..)+"
+               #"(?:%[A-Za-z0-9]{2})+"
                (fn [chars]
                  (-> ^bytes (parse-bytes chars)
                      (String. (or encoding "UTF-8"))

--- a/test/ring/util/test/codec.clj
+++ b/test/ring/util/test/codec.clj
@@ -9,6 +9,7 @@
   (is (= (percent-encode "foo") "%66%6F%6F")))
 
 (deftest test-percent-decode
+  (is (= (percent-decode "%s/") "%s/"))
   (is (= (percent-decode "%20") " "))
   (is (= (percent-decode "foo%20bar") "foo bar"))
   (is (= (percent-decode "foo%FE%FF%00%2Fbar" "UTF-16") "foo/bar"))


### PR DESCRIPTION
We might want to throw an exception to allow users to return a `400 Bad Request`… Otherwise, fixes #7 by simply ignoring codes that can't be decoded.