### PR TITLE
Treat sets in form-encode like seq or sequential

### DIFF
--- a/src/ring/util/codec.clj
+++ b/src/ring/util/codec.clj
@@ -92,7 +92,7 @@
       (->> params
            (mapcat
             (fn [[k v]]
-              (if (or (seq? v) (sequential? v) )
+              (if (or (seq? v) (sequential? v) (set? v))
                 (map #(encode-param [k %]) v)
                 [(encode-param [k v])])))
            (str/join "&"))))


### PR DESCRIPTION
This extends encoding so that sets are treated in the same way as e.g. vectors. Although there is no strict standard for encoding array-like objects as query strings I think it makes sense that encoding `{:a #{1 2}}` should result in the same thing as `{:a [1 2]}` instead of resulting in the encoding of the string `"#{1 2}"`. This way it will return `"a=1&a=2"` instead of `"a=%23%7B1+2%7D"`.  

Especially if used for client side consumption or non-clojure based libraries, doesn't it make sense to have a set be represented as some array-like thing?  Or maybe there is a good reason not to do this I'm not aware of or this shouldn't be included because a standard doesn't exist. Thanks.