### PR TITLE
fix wrong operation with '+' in url-encode and url-decode

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/ring-clojure/ring-codec"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.3.0"]
                  [commons-codec "1.6"]]
   :plugins [[codox "0.8.0"]]
   :codox {:src-dir-uri "http://github.com/ring-clojure/ring-codec/blob/1.0.0/"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/ring-clojure/ring-codec"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.3.0"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
                  [commons-codec "1.6"]]
   :plugins [[codox "0.8.0"]]
   :codox {:src-dir-uri "http://github.com/ring-clojure/ring-codec/blob/1.0.0/"

--- a/src/ring/util/codec.clj
+++ b/src/ring/util/codec.clj
@@ -57,7 +57,7 @@
   "Returns the url-encoded version of the given string, using either a specified
   encoding or UTF-8 by default."
   [unencoded & [encoding]]
-  (some-> unencoded
+  (-> unencoded
     (str/replace
       #"[^A-Za-z0-9_~.+-]+"
       #(double-escape (percent-encode % encoding)))
@@ -67,7 +67,7 @@
   "Returns the url-decoded version of the given string, using either a specified
   encoding or UTF-8 by default. If the encoding is invalid, nil is returned."
   [encoded & [encoding]]
-  (some-> encoded
+  (-> encoded
     (.replace "+" " ")
     (percent-decode encoding)))
 

--- a/src/ring/util/codec.clj
+++ b/src/ring/util/codec.clj
@@ -57,16 +57,19 @@
   "Returns the url-encoded version of the given string, using either a specified
   encoding or UTF-8 by default."
   [unencoded & [encoding]]
-  (str/replace
-    unencoded
-    #"[^A-Za-z0-9_~.+-]+"
-    #(double-escape (percent-encode % encoding))))
+  (some-> unencoded
+    (str/replace
+      #"[^A-Za-z0-9_~.+-]+"
+      #(double-escape (percent-encode % encoding)))
+    (.replace "+" "%2B")))
 
 (defn ^String url-decode
   "Returns the url-decoded version of the given string, using either a specified
   encoding or UTF-8 by default. If the encoding is invalid, nil is returned."
   [encoded & [encoding]]
-  (percent-decode encoded encoding))
+  (some-> encoded
+    (.replace "+" " ")
+    (percent-decode encoding)))
 
 (defn base64-encode
   "Encode an array of bytes into a base64 encoded string."

--- a/test/ring/util/test/codec.clj
+++ b/test/ring/util/test/codec.clj
@@ -18,12 +18,14 @@
 (deftest test-url-encode
   (is (= (url-encode "foo/bar") "foo%2Fbar"))
   (is (= (url-encode "foo/bar" "UTF-16") "foo%FE%FF%00%2Fbar"))
-  (is (= (url-encode "foo+bar") "foo+bar"))
+  (is (= (url-encode "foo+bar") "foo%2Bbar"))
   (is (= (url-encode "foo bar") "foo%20bar")))
 
 (deftest test-url-decode
   (is (= (url-decode "foo%2Fbar") "foo/bar" ))
   (is (= (url-decode "foo%FE%FF%00%2Fbar" "UTF-16") "foo/bar"))
+  (is (= (url-decode "foo%2Bbar") "foo+bar"))
+  (is (= (url-decode "foo+bar") "foo bar"))
   (is (= (url-decode "%") "%")))
 
 (deftest test-base64-encoding


### PR DESCRIPTION
* url-encode

```clj
(url-encode "foo+bar")
```

should be `foo%2Bbar` not `foo+bar`

```clj
(url-decode "foo+bar")
```

should be `foo bar` not `foo+bar`