### PR TITLE
Extending FormEncodeable to nil values

### DIFF
--- a/src/ring/util/codec.clj
+++ b/src/ring/util/codec.clj
@@ -98,7 +98,9 @@
            (str/join "&"))))
   Object
   (form-encode* [x encoding]
-    (form-encode* (str x) encoding)))
+    (form-encode* (str x) encoding))
+  nil
+  (form-encode* [x encoding] ""))
 
 (defn form-encode
   "Encode the supplied value into www-form-urlencoded format, often used in

--- a/test/ring/util/test/codec.clj
+++ b/test/ring/util/test/codec.clj
@@ -42,6 +42,7 @@
       {"a" "b"} "a=b"
       {:a "b"}  "a=b"
       {"a" 1}   "a=1"
+      {"a" nil} "a="
       {"a" "b" "c" "d"} "a=b&c=d"
       {"a" "b c"}       "a=b+c")
     (is (= (form-encode {"a" "foo/bar"} "UTF-16") "a=foo%FE%FF%00%2Fbar"))))


### PR DESCRIPTION
Closes #17.

Extending `FormEncodeable` to `nil` values is useful when we have map parameters like `{:a nil}` to test malformed requests.

```clj
{:a nil} => "a="
```