### PR TITLE
ring-core issue #312 can't use query parameters without a value

### DIFF
--- a/src/ring/util/codec.clj
+++ b/src/ring/util/codec.clj
@@ -142,7 +142,7 @@
      (reduce
       (fn [m param]
         (if-let [[k v] (str/split param #"=" 2)]
-          (assoc-conj m (form-decode-str k encoding) (form-decode-str v encoding))
+          (assoc-conj m (form-decode-str k encoding) (form-decode-str (or v "") encoding))
           m))
       {}
       (str/split encoded #"&")))))

--- a/test/ring/util/test/codec.clj
+++ b/test/ring/util/test/codec.clj
@@ -62,6 +62,9 @@
     "a=b&c=d" {"a" "b" "c" "d"}
     "foo+bar" "foo bar"
     "a=b+c"   {"a" "b c"}
-    "a=b%2Fc" {"a" "b/c"})
+    "a=b%2Fc" {"a" "b/c"}
+    "a=b&c"   {"a" "b" "c" ""}
+    "a=&b=c"  {"a" "" "b" "c"}
+    "a&b=c"   {"a" "" "b" "c"})
   (is (= (form-decode "a=foo%FE%FF%00%2Fbar" "UTF-16")
          {"a" "foo/bar"})))


### PR DESCRIPTION
This change allows the use query parameters without an
accompanying "=" and value as used by some rest API's.
The issue was actually reported in the ring core project,
not on this utility lib.