### PR TITLE
ensure form-decode-str encoding is a String

### DIFF
--- a/src/ring/util/codec.clj
+++ b/src/ring/util/codec.clj
@@ -126,6 +126,9 @@
   ([encoded]
    (form-decode-str encoded "UTF-8"))
   ([^String encoded encoding]
+   (when-not (string? encoding)
+     (throw (ex-info "encoding must be a String"
+                     {:encoded encoded :encoding encoding})))
    (try
      (URLDecoder/decode encoded encoding)
      (catch Exception _ nil))))

--- a/test/ring/util/test/codec.clj
+++ b/test/ring/util/test/codec.clj
@@ -1,7 +1,8 @@
 (ns ring.util.test.codec
   (:use clojure.test
         ring.util.codec)
-  (:import java.util.Arrays))
+  (:import java.util.Arrays
+           clojure.lang.ExceptionInfo))
 
 (deftest test-percent-encode
   (is (= (percent-encode " ") "%20"))
@@ -53,7 +54,11 @@
 
 (deftest test-form-decode-str
   (is (= (form-decode-str "foo=bar+baz") "foo=bar baz"))
-  (is (nil? (form-decode-str "%D"))))
+  (is (nil? (form-decode-str "%D")))
+  (is (thrown-with-msg?
+       ExceptionInfo
+       #"encoding must be a String"
+       (form-decode-str "foo" nil))))
 
 (deftest test-form-decode
   (are [x y] (= (form-decode x) y)


### PR DESCRIPTION
throws an Exception if the `encoding` arg given to the arity-2 version of
`form-decode-str` is not a `String` value, because a `nil` `encoding` will
cause a surprising `{nil nil}` parse result

addresses issue: #22 

