### PR TITLE
Invalid url encoding handling

### DIFF
--- a/src/ring/util/codec.clj
+++ b/src/ring/util/codec.clj
@@ -141,8 +141,11 @@
      (form-decode-str encoded encoding)
      (reduce
       (fn [m param]
-        (if-let [[k v] (str/split param #"=" 2)]
-          (assoc-conj m (form-decode-str k encoding) (form-decode-str (or v "") encoding))
-          m))
+        (let [[k v] (str/split param #"=" 2)
+              k     (form-decode-str k encoding)
+              v     (form-decode-str (or v "") encoding)]
+          (if (and k v)
+            (assoc-conj m k v)
+            m)))
       {}
       (str/split encoded #"&")))))

--- a/test/ring/util/test/codec.clj
+++ b/test/ring/util/test/codec.clj
@@ -71,8 +71,8 @@
     "=b"      {"" "b"})
   (testing "invalid URL encoding"
     (are [x y] (= (form-decode x) y)
-      "%=b" {nil "b"}
-      "a=%" {"a" nil}
-      "%=%" {nil nil}))
+      "%=b" {}
+      "a=%" {}
+      "%=%" {}))
   (is (= (form-decode "a=foo%FE%FF%00%2Fbar" "UTF-16")
          {"a" "foo/bar"})))

--- a/test/ring/util/test/codec.clj
+++ b/test/ring/util/test/codec.clj
@@ -65,6 +65,14 @@
     "a=b%2Fc" {"a" "b/c"}
     "a=b&c"   {"a" "b" "c" ""}
     "a=&b=c"  {"a" "" "b" "c"}
-    "a&b=c"   {"a" "" "b" "c"})
+    "a&b=c"   {"a" "" "b" "c"}
+    "="       {"" ""}
+    "a="      {"a" ""}
+    "=b"      {"" "b"})
+  (testing "invalid URL encoding"
+    (are [x y] (= (form-decode x) y)
+      "%=b" {nil "b"}
+      "a=%" {"a" nil}
+      "%=%" {nil nil}))
   (is (= (form-decode "a=foo%FE%FF%00%2Fbar" "UTF-16")
          {"a" "foo/bar"})))


### PR DESCRIPTION
Given the squashing of all exceptions in form-decode-str, the prior implementation of form-decode would return nil keys and/or values for parameters which failed to URL decode.  With this change the parameters are silently dropped.

Including nil parameters creates problems for downstream middleware (e.g. ring.middleware.nested-params -- see ring-clojure/ring#243) which are not expecting them.

One can second guess the decision to catch all decoding exceptions (see #22) rather than allowing them to bubble up (and thus potentially allow the application to return an error status), but that decision being what it is, it seems most in the spirit of the library to drop the invalid parameters.

Note the two commits, with the first locking down the existing behavior so the second can clearly show the changes in behavior.