### PR TITLE
[codec] Type hint to silence reflection warnings

### DIFF
--- a/src/ring/util/codec.clj
+++ b/src/ring/util/codec.clj
@@ -5,6 +5,8 @@
            [java.net URLEncoder URLDecoder]
            [java.util Base64]))
 
+(set! *warn-on-reflection* true)
+
 (defn assoc-conj
   "Associate a key with a value in a map. If the key already exists in the map,
   a vector of values is associated with the key."
@@ -77,7 +79,7 @@
 
 (defn base64-encode
   "Encode an array of bytes into a base64 encoded string."
-  [unencoded]
+  [^bytes unencoded]
   (String. (.encode (Base64/getEncoder) unencoded)))
 
 (defn base64-decode


### PR DESCRIPTION
Hello, thanks for your continued effort on all these awesome libraries - `ring` is crucial to our operation and I'm very grateful for it.

Before this change:
```
$ lein check
Compiling namespace ring.util.codec
Reflection warning, ring/util/codec.clj:81:12 - call to encode can't be resolved.
Reflection warning, ring/util/codec.clj:81:3 - call to java.lang.String ctor can't be resolved.
```

After this change:
```
$ lein check
Compiling namespace ring.util.codec
```

The actual change is a bit more interesting than it looks, `.encode` is overloaded on the encoder to take either `byte[]` or a `java.nio.ByteBuffer`.

Interestingly, our function `ring.util.codec/base64-encode` is broken for `ByteBuffer` inputs, because when `.encode` is called on a `ByteBuffer` it returns a `ByteBuffer`, and there is no `String.` constructor that takes a `ByteBuffer`.

Not sure if we'd be interested in supporting growing the set of acceptable inputs to  `ring.util.codec/base64-encode`, but this change aims to eliminate the reflection warning without breaking the function for any current inputs.

---

With warm appreciation for your time and consideration.
