### PR TITLE
Add type hint to silence reflection warnings

### DIFF
--- a/src/ring/util/codec.clj
+++ b/src/ring/util/codec.clj
@@ -77,7 +77,7 @@
 
 (defn base64-encode
   "Encode an array of bytes into a base64 encoded string."
-  [unencoded]
+  [^bytes unencoded]
   (String. (.encode (Base64/getEncoder) unencoded)))
 
 (defn base64-decode


### PR DESCRIPTION
Before:
```
$ lein check
Compiling namespace ring.util.codec
Reflection warning, ring/util/codec.clj:81:12 - call to encode can't be resolved.
Reflection warning, ring/util/codec.clj:81:3 - call to java.lang.String ctor can't be resolved.
```

After:
```
$ lein check
Compiling namespace ring.util.codec
```