### PR TITLE
Use UTF-8 encoding when nil encoding provided to form-decode/-str

### DIFF
--- a/src/ring/util/codec.clj
+++ b/src/ring/util/codec.clj
@@ -126,7 +126,7 @@
    (form-decode-str encoded "UTF-8"))
   ([^String encoded ^String encoding]
    (try
-     (URLDecoder/decode encoded encoding)
+     (URLDecoder/decode encoded ^String (or encoding "UTF-8"))
      (catch Exception _ nil))))
 
 (defn form-decode

--- a/test/ring/util/test/codec.clj
+++ b/test/ring/util/test/codec.clj
@@ -53,7 +53,9 @@
 
 (deftest test-form-decode-str
   (is (= (form-decode-str "foo=bar+baz") "foo=bar baz"))
-  (is (nil? (form-decode-str "%D"))))
+  (is (nil? (form-decode-str "%D")))
+  (is (= (form-decode-str "foo=bar+baz" nil) "foo=bar baz"))
+  (is (= (form-decode-str "foo=bar+baz" "UTF-8") "foo=bar baz")))
 
 (deftest test-form-decode
   (are [x y] (= (form-decode x) y)
@@ -75,4 +77,6 @@
       "a=%" {}
       "%=%" {}))
   (is (= (form-decode "a=foo%FE%FF%00%2Fbar" "UTF-16")
+         {"a" "foo/bar"}))
+  (is (= (form-decode "a=foo%2Fbar" nil)
          {"a" "foo/bar"})))


### PR DESCRIPTION
Fixes ring-clojure/ring-codec#32
