### PR TITLE
Only decode hexadecimal percent codes

### DIFF
--- a/src/ring/util/codec.clj
+++ b/src/ring/util/codec.clj
@@ -56,7 +56,7 @@
    (percent-decode encoded "UTF-8"))
   ([^String encoded ^String encoding]
    (str/replace encoded
-                #"(?:%[A-Za-z0-9]{2})+"
+                #"(?:%[A-Fa-f0-9]{2})+"
                 (fn [chars]
                   (-> (parse-bytes chars)
                       (String. encoding)

--- a/test/ring/util/test/codec.clj
+++ b/test/ring/util/test/codec.clj
@@ -9,7 +9,7 @@
   (is (= (percent-encode "foo") "%66%6F%6F")))
 
 (deftest test-percent-decode
-  (is (= (percent-decode "%s/") "%s/"))
+  (is (= (percent-decode "%s4/") "%s4/"))
   (is (= (percent-decode "%20") " "))
   (is (= (percent-decode "foo%20bar") "foo bar"))
   (is (= (percent-decode "foo%FE%FF%00%2Fbar" "UTF-16") "foo/bar"))


### PR DESCRIPTION
The percent codes are hexadecimal so we can ignore any letters other than a-f.
Any letter aside from these would cause a NumberFormatException when
attempting to decode them.