### PR TITLE
Remove reader eval invocation

### DIFF
--- a/src/ring/util/codec.clj
+++ b/src/ring/util/codec.clj
@@ -157,8 +157,10 @@
             (recur (f result (.nextToken tokenizer)))
             result))))))
 
+(def ^:private ^:const kv-separator (int \=))
+
 (defn- split-key-value-pair [^String s]
-  (let [i (.indexOf s #=(int \=))]
+  (let [i (.indexOf s kv-separator)]
     (cond
       (pos? i)  (MapEntry. (.substring s 0 i) (.substring s (inc i)))
       (zero? i) (MapEntry. "" (.substring s (inc i)))


### PR DESCRIPTION
This helps with reading the source code under recommended and more secure `(binding [*read-eval* false] ...)` binding.