### PR TITLE
Update Clojure to 1.9.0 (addresses CVE-2017-20189)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/ring-clojure/ring-codec"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.7.0"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]]
   :plugins [[lein-codox "0.10.7"]]
   :codox
   {:output-path "codox"


### PR DESCRIPTION
[CVE-2017-20189](https://nvd.nist.gov/vuln/detail/CVE-2017-20189) is a critical security vulnerability affecting versions of Clojure prior to `1.9.0`.

Can we bump this project's dependency to `1.9.0` and cut a new release?